### PR TITLE
Pysäköintipaikkojen määrä -esimerkit ja build-korjauksia

### DIFF
--- a/.github/workflows/onPullRequest.yml
+++ b/.github/workflows/onPullRequest.yml
@@ -17,6 +17,7 @@ jobs:
     needs: list-examples
     runs-on: ubuntu-latest
     strategy:
+        fail-fast: false
         matrix:
             file: ${{ fromJson(needs.list-examples.outputs.matrix) }}
     steps:

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           git config --local user.name "actions-user[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --ff-only
+          git pull --all --ff-only
           git diff --quiet || (git add -f ${{ matrix.file }}.md && git commit -m "Updated MD file ${{ matrix.file }}.md")
           git push
       - id: commit-new
@@ -42,7 +42,7 @@ jobs:
         run: |
           git config --local user.name "actions-user[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --ff-only
+          git pull --all --ff-only
           git add -f ${{ matrix.file }}.md
           git commit -m "Created MD file ${{ matrix.file }}.md"
           git push

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
+      fail-fast: false
       matrix:
         file: ${{ fromJson(needs.list-examples.outputs.matrix) }}
     steps:

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -17,6 +17,7 @@ jobs:
     needs: list-examples
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         file: ${{ fromJson(needs.list-examples.outputs.matrix) }}
     steps:
@@ -34,7 +35,7 @@ jobs:
         run: |
           git config --local user.name "actions-user[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --all --ff-only
+          git pull --ff-only
           git diff --quiet || (git add -f ${{ matrix.file }}.md && git commit -m "Updated MD file ${{ matrix.file }}.md")
           git push
       - id: commit-new
@@ -42,7 +43,7 @@ jobs:
         run: |
           git config --local user.name "actions-user[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --all --ff-only
+          git pull --ff-only
           git add -f ${{ matrix.file }}.md
           git commit -m "Created MD file ${{ matrix.file }}.md"
           git push

--- a/json-esimerkit/kaavoitus/kayttotarkoitukset/SpatialPlan-poisluettavaKayttotarkoitus.md
+++ b/json-esimerkit/kaavoitus/kayttotarkoitukset/SpatialPlan-poisluettavaKayttotarkoitus.md
@@ -1,0 +1,137 @@
+# json-esimerkit/kaavoitus/kayttotarkoitukset/SpatialPlan-poisluettavaKayttotarkoitus 
+Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/kayttotarkoitukset/SpatialPlan-poisluettavaKayttotarkoitus.yml. Älä muokkaa tätä tiedostoa käsin.
+```json
+{
+  "planKey": "43ec642a-61d7-427d-9aa1-4046ca994b54",
+  "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+  "planDescription": "Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.\n\nKunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa alueelle laadukasta ja hyvää ympäristöä.",
+  "geographicalArea": {
+    "srid": "3880",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            26478230.97832,
+            7029409.73545
+          ],
+          [
+            26478319.31953,
+            7029563.05089
+          ],
+          [
+            26478367.60318,
+            7029567.15694
+          ],
+          [
+            26478423.13736,
+            7029571.87958
+          ],
+          [
+            26478592.47984,
+            7029586.2805
+          ],
+          [
+            26478535.52301,
+            7029392.31324
+          ],
+          [
+            26478372.27445,
+            7029401.65226
+          ],
+          [
+            26478230.97832,
+            7029409.73545
+          ]
+        ]
+      ]
+    }
+  },
+  "planObjects": [
+    {
+      "planObjectKey": "7c093fdb-21e3-4ba7-8a20-aa682ce56666",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Asumisen alueen kaavakohde"
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      }
+    }
+  ],
+  "planRegulationGroups": [
+    {
+      "planRegulationGroupKey": "b4e8033a-20dc-4eea-90f5-b0f7fa3f985d",
+      "titleOfPlanRegulation": {
+        "fin": "Asumisen korttelialue poislukien maatilan talouskeskus"
+      },
+      "letterIdentifier": "A-1",
+      "planRegulations": [
+        {
+          "planRegulationKey": "fece18b9-74d0-4067-a48e-b30577300e42",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            },
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/poisluettavaKayttotarkoitus",
+              "value": {
+                "dataType": "Code",
+                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maatilanTalouskeskuksenAlue"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "planRegulationGroupRelations": [
+    {
+      "planObjectKey": "7c093fdb-21e3-4ba7-8a20-aa682ce56666",
+      "planRegulationGroupKey": "b4e8033a-20dc-4eea-90f5-b0f7fa3f985d"
+    }
+  ]
+}
+```

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/README.md
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/README.md
@@ -1,0 +1,24 @@
+# Pysäköintipaikkojen määrä
+
+Esimerkkejä liittyen seuraaviin määräyslajeihin:
+* [Autopaikkojen määrä](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/autopaikkojenMaara)
+* [Kerrosneliömäärä yhtä autopaikkaa kohden](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaAutopaikkaaKohden)
+* [Autopaikkojen määrä asuntoa kohden](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/autopaikkojenMaaraAsuntoaKohden)
+* [Pyöräpaikkojen määrä](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pyorapaikkojenMaara)
+* [Kerrosneliömäärä yhtä pyöräpaikkaa kohden](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaPyorapaikkaaKohden)
+* [Pyöräpaikkojen määrä asuntoa kohden](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pyorapaikkojenMaaraAsuntoaKohden)
+* [Pysäköinnin alue](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pysakoinninAlue)
+
+## SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden
+Sisältää sekä autopaikkojen että polkupyöräpaikkojen mitoitusmääräykset.
+
+YAML: [SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml](./SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml)
+
+JSON: [SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden](./SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.md) (generoitu automaattisesti)
+
+## SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden
+Sisältää sekä autopaikkojen että polkupyöräpaikkojen mitoitusmääräykset.
+
+YAML: [SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml](./SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml)
+
+JSON: [SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden](./SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.md) (generoitu automaattisesti)

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.md
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.md
@@ -1,0 +1,264 @@
+# json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden 
+Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml. Älä muokkaa tätä tiedostoa käsin.
+```json
+{
+  "planKey": "43ec642a-61d7-427d-9aa1-4046ca994b54",
+  "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+  "planDescription": "Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.\n\nKunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa alueelle laadukasta ja hyvää ympäristöä.",
+  "geographicalArea": {
+    "srid": "3880",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            26478230.97832,
+            7029409.73545
+          ],
+          [
+            26478319.31953,
+            7029563.05089
+          ],
+          [
+            26478367.60318,
+            7029567.15694
+          ],
+          [
+            26478423.13736,
+            7029571.87958
+          ],
+          [
+            26478592.47984,
+            7029586.2805
+          ],
+          [
+            26478535.52301,
+            7029392.31324
+          ],
+          [
+            26478372.27445,
+            7029401.65226
+          ],
+          [
+            26478230.97832,
+            7029409.73545
+          ]
+        ]
+      ]
+    }
+  },
+  "planObjects": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "AK-alueen kaavakohde"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Maanalaisen auton säilytyspaikan kaavakohde"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/01",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    }
+  ],
+  "planRegulationGroups": [
+    {
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f",
+      "titleOfPlanRegulation": {
+        "fin": "Kerrostalovaltainen asuntoalue"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "55e1f047-8c55-432a-9086-1642de870410",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asuinkerrostaloalue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e",
+      "titleOfPlanRegulation": {
+        "fin": "Auton säilytyspaikan rakennusala"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "51635e36-7531-474c-be5c-0f34912f8419",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue"
+            },
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus",
+              "value": {
+                "dataType": "Code",
+                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pysakoinninAlue",
+                "codeList": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "8bad201c-2969-4717-b8b5-ff40d4be0855",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusoikeus kerrosalaneliömetreinä"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "425cacfe-c217-4095-a362-6fd9a98aac6a",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 2300,
+            "unitOfMeasure": "k-m2"
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "b3bcc433-f424-414d-b3f2-cee006f50823",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta kerrosalaneliömetriä kohti on rakennettava yksi autopaikka"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "15aea3bc-0653-4f91-8815-cb2e4b8813d4",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaAutopaikkaaKohden",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 41
+          }
+        },
+        {
+          "planRegulationKey": "15aea3bc-0653-4f91-8815-cb2e4b8813d4",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaPyorapaikkaaKohden",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 20
+          }
+        }
+      ]
+    }
+  ],
+  "planRegulationGroupRelations": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "b3bcc433-f424-414d-b3f2-cee006f50823"
+    },
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "8bad201c-2969-4717-b8b5-ff40d4be0855"
+    }
+  ]
+}
+```

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.md
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.md
@@ -231,7 +231,7 @@ Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/pysakointipa
           }
         },
         {
-          "planRegulationKey": "15aea3bc-0653-4f91-8815-cb2e4b8813d4",
+          "planRegulationKey": "45bc3a2e-642b-42f3-83f9-30cbdf00ede2",
           "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
           "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaPyorapaikkaaKohden",
           "value": {

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.meta
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.meta
@@ -1,0 +1,2 @@
+planType: '31'
+administrativeAreaIdentifiers: '601'

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml
@@ -1,0 +1,160 @@
+planKey: 43ec642a-61d7-427d-9aa1-4046ca994b54
+lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+planDescription: >-
+  Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.
+
+
+  Kunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa
+  alueelle laadukasta ja hyvää ympäristöä.
+geographicalArea:
+  srid: '3880'
+  geometry:
+    type: Polygon
+    coordinates:
+      - - - 26478230.97832
+          - 7029409.73545
+        - - 26478319.31953
+          - 7029563.05089
+        - - 26478367.60318
+          - 7029567.15694
+        - - 26478423.13736
+          - 7029571.87958
+        - - 26478592.47984
+          - 7029586.2805
+        - - 26478535.52301
+          - 7029392.31324
+        - - 26478372.27445
+          - 7029401.65226
+        - - 26478230.97832
+          - 7029409.73545
+planObjects:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: AK-alueen kaavakohde
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478230.97832
+              - 7029409.73545
+            - - 26478319.31953
+              - 7029563.05089
+            - - 26478367.60318
+              - 7029567.15694
+            - - 26478423.13736
+              - 7029571.87958
+            - - 26478592.47984
+              - 7029586.2805
+            - - 26478535.52301
+              - 7029392.31324
+            - - 26478372.27445
+              - 7029401.65226
+            - - 26478230.97832
+              - 7029409.73545
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Maanalaisen auton säilytyspaikan kaavakohde
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478230.97832
+              - 7029409.73545
+            - - 26478319.31953
+              - 7029563.05089
+            - - 26478367.60318
+              - 7029567.15694
+            - - 26478423.13736
+              - 7029571.87958
+            - - 26478592.47984
+              - 7029586.2805
+            - - 26478535.52301
+              - 7029392.31324
+            - - 26478372.27445
+              - 7029401.65226
+            - - 26478230.97832
+              - 7029409.73545
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/01
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+planRegulationGroups:
+  - planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    titleOfPlanRegulation:
+      fin: Kerrostalovaltainen asuntoalue
+    planRegulations:
+      - planRegulationKey: 55e1f047-8c55-432a-9086-1642de870410
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asuinkerrostaloalue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+  - planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    titleOfPlanRegulation:
+      fin: Auton säilytyspaikan rakennusala
+    planRegulations:
+      - planRegulationKey: 51635e36-7531-474c-be5c-0f34912f8419
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus
+            value:
+              dataType: Code
+              code: >-
+                http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pysakoinninAlue
+              codeList: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
+  - planRegulationGroupKey: 8bad201c-2969-4717-b8b5-ff40d4be0855
+    titleOfPlanRegulation:
+      fin: Rakennusoikeus kerrosalaneliömetreinä
+    planRegulations:
+      - planRegulationKey: 425cacfe-c217-4095-a362-6fd9a98aac6a
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        value:
+          dataType: PositiveNumeric
+          number: 2300
+          unitOfMeasure: k-m2
+  - planRegulationGroupKey: b3bcc433-f424-414d-b3f2-cee006f50823
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta kerrosalaneliömetriä kohti on rakennettava yksi autopaikka
+    planRegulations:
+      - planRegulationKey: 15aea3bc-0653-4f91-8815-cb2e4b8813d4
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaAutopaikkaaKohden
+        value:
+          dataType: PositiveNumeric
+          number: 41
+      - planRegulationKey: 15aea3bc-0653-4f91-8815-cb2e4b8813d4
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaPyorapaikkaaKohden
+        value:
+          dataType: PositiveNumeric
+          number: 20
+planRegulationGroupRelations:
+    # Kerrostalovaltainen asuntoalue -> AK-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    #
+    # Pysäköintipaikan rakennusala -> Maanalaisen auton säilytyspaikan kaavakohde:
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Neliöiden määrä per autopaikka -> AK-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: b3bcc433-f424-414d-b3f2-cee006f50823
+    #
+    # Rakennusoikeus kerrosalaneliömetreinä -> AK-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: 8bad201c-2969-4717-b8b5-ff40d4be0855
+

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml
@@ -134,7 +134,7 @@ planRegulationGroups:
         value:
           dataType: PositiveNumeric
           number: 41
-      - planRegulationKey: 15aea3bc-0653-4f91-8815-cb2e4b8813d4
+      - planRegulationKey: 45bc3a2e-642b-42f3-83f9-30cbdf00ede2
         lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
         type: >-
           http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/kerrosneliomaaraYhtaPyorapaikkaaKohden

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.md
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.md
@@ -1,0 +1,159 @@
+# json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden 
+Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml. Älä muokkaa tätä tiedostoa käsin.
+```json
+{
+  "planKey": "43ec642a-61d7-427d-9aa1-4046ca994b54",
+  "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+  "planDescription": "Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.\n\nKunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa alueelle laadukasta ja hyvää ympäristöä.",
+  "geographicalArea": {
+    "srid": "3880",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            26478230.97832,
+            7029409.73545
+          ],
+          [
+            26478319.31953,
+            7029563.05089
+          ],
+          [
+            26478367.60318,
+            7029567.15694
+          ],
+          [
+            26478423.13736,
+            7029571.87958
+          ],
+          [
+            26478592.47984,
+            7029586.2805
+          ],
+          [
+            26478535.52301,
+            7029392.31324
+          ],
+          [
+            26478372.27445,
+            7029401.65226
+          ],
+          [
+            26478230.97832,
+            7029409.73545
+          ]
+        ]
+      ]
+    }
+  },
+  "planObjects": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "AK-alueen kaavakohde"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02"
+    }
+  ],
+  "planRegulationGroups": [
+    {
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f",
+      "titleOfPlanRegulation": {
+        "fin": "Kerrostalovaltainen asuntoalue"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "55e1f047-8c55-432a-9086-1642de870410",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asuinkerrostaloalue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "b3bcc433-f424-414d-b3f2-cee006f50823",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta kerrosalaneliömetriä kohti on rakennettava yksi autopaikka"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "15aea3bc-0653-4f91-8815-cb2e4b8813d4",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/autopaikkojenMaaraAsuntoaKohden",
+          "value": {
+            "dataType": "PositiveDecimal",
+            "number": 0.4
+          }
+        },
+        {
+          "planRegulationKey": null,
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pyorapaikkojenMaaraAsuntoaKohden",
+          "value": {
+            "dataType": "PositiveDecimal",
+            "number": 1.2
+          }
+        }
+      ]
+    }
+  ],
+  "planRegulationGroupRelations": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f"
+    },
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "b3bcc433-f424-414d-b3f2-cee006f50823"
+    }
+  ]
+}
+```

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.md
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.md
@@ -134,7 +134,7 @@ Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/pysakointipa
           }
         },
         {
-          "planRegulationKey": null,
+          "planRegulationKey": "223fdc50-bdbe-4ecf-b313-eb77e8dd6c08",
           "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
           "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pyorapaikkojenMaaraAsuntoaKohden",
           "value": {

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.meta
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.meta
@@ -1,0 +1,2 @@
+planType: '31'
+administrativeAreaIdentifiers: '601'

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml
@@ -1,0 +1,94 @@
+planKey: 43ec642a-61d7-427d-9aa1-4046ca994b54
+lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+planDescription: >-
+  Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.
+
+
+  Kunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa
+  alueelle laadukasta ja hyvää ympäristöä.
+geographicalArea:
+  srid: '3880'
+  geometry:
+    type: Polygon
+    coordinates:
+      - - - 26478230.97832
+          - 7029409.73545
+        - - 26478319.31953
+          - 7029563.05089
+        - - 26478367.60318
+          - 7029567.15694
+        - - 26478423.13736
+          - 7029571.87958
+        - - 26478592.47984
+          - 7029586.2805
+        - - 26478535.52301
+          - 7029392.31324
+        - - 26478372.27445
+          - 7029401.65226
+        - - 26478230.97832
+          - 7029409.73545
+planObjects:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: AK-alueen kaavakohde
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478230.97832
+              - 7029409.73545
+            - - 26478319.31953
+              - 7029563.05089
+            - - 26478367.60318
+              - 7029567.15694
+            - - 26478423.13736
+              - 7029571.87958
+            - - 26478592.47984
+              - 7029586.2805
+            - - 26478535.52301
+              - 7029392.31324
+            - - 26478372.27445
+              - 7029401.65226
+            - - 26478230.97832
+              - 7029409.73545
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+planRegulationGroups:
+  - planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    titleOfPlanRegulation:
+      fin: Kerrostalovaltainen asuntoalue
+    planRegulations:
+      - planRegulationKey: 55e1f047-8c55-432a-9086-1642de870410
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asuinkerrostaloalue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+  - planRegulationGroupKey: b3bcc433-f424-414d-b3f2-cee006f50823
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta kerrosalaneliömetriä kohti on rakennettava yksi autopaikka
+    planRegulations:
+      - planRegulationKey: 15aea3bc-0653-4f91-8815-cb2e4b8813d4
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/autopaikkojenMaaraAsuntoaKohden
+        value:
+          dataType: PositiveDecimal
+          number: 0.4
+      - planRegulationKey: 
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pyorapaikkojenMaaraAsuntoaKohden
+        value:
+          dataType: PositiveDecimal
+          number: 1.2
+planRegulationGroupRelations:
+    # Kerrostalovaltainen asuntoalue -> AK-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    #
+    # Autopaikkojen lukumäärä per asunto -> AK-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: b3bcc433-f424-414d-b3f2-cee006f50823

--- a/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml
+++ b/json-esimerkit/kaavoitus/pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml
@@ -77,7 +77,7 @@ planRegulationGroups:
         value:
           dataType: PositiveDecimal
           number: 0.4
-      - planRegulationKey: 
+      - planRegulationKey: 223fdc50-bdbe-4ecf-b313-eb77e8dd6c08
         lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
         type: >-
           http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/pyorapaikkojenMaaraAsuntoaKohden


### PR DESCRIPTION
* Lisätty esimerkit ```pysakointipaikkojen-maara/SpatialPlan-kerrosneliomaaraYhtaPysakointipaikkaaKohden.yml``` ja ```pysakointipaikkojen-maara/SpatialPlan-pysakointipaikkojenMaaraAsuntoaKohden.yml```
* Muutettu esimerkkien MD-tiedostojen generoinnin aiheuttavat onPush-build siten, että eri esimerkkien validointi ja buildaus eivät mene rinnakkain. Näin estetään repon epäsynkronisuusongelmat, kun JSON-muotoisia esimerkkejä sisältäviä MD-tiedostoja luodaan tai muutetaan automaattisesti osana build-prosessia