### PR TITLE
Kolme uutta esimerkkiä rakennusoikeuden kohdistamisesta käyttötarkoituskohtaisesti rakennusaloille

### DIFF
--- a/json-esimerkit/kaavoitus/sallittuKerrosala/README.md
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/README.md
@@ -1,6 +1,6 @@
 # Sallittu kerrosala
 
-Esimerkkejä [Sallittu kerrosala](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala)-kaavamääräyslajin ja siihen liittyen listietoja käytöstä.
+Esimerkkejä [Sallittu kerrosala](http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala)-kaavamääräyslajin ja siihen liittyen lisätietojen käytöstä.
 
 ## SpatialPlan-kayttotarkoituksenOsuusKerrosalasta
 ![kuva esimerkista](kuvat/kayttotarkoituksen-osuus-kerrosalasta-syke.png "Käyttötarkoituksen osuuus kerrosalasta")
@@ -12,8 +12,17 @@ JSON: [SpatialPlan-kayttotarkoituksenOsuusKerrosalasta](./SpatialPlan-kayttotark
 ## SpatialPlan-kayttotarkoituskohdistus
 ![kuva esimerkista](kuvat/kayttotarkoituskohdistus-syke.png "Käyttötarkoituskohdistus")
 
-Esimerkissä onm myös AL-alueen kaavakohde ja sen aluevaraus annettu, toisin kuin yo. kuvassa.
+Esimerkissä on myös AL-alueen kaavakohde ja sen aluevaraus annettu, toisin kuin yo. kuvassa.
 
 YAML: [SpatialPlan-kayttotarkoituskohdistus.yml](./SpatialPlan-kayttotarkoituskohdistus.yml)
 
 JSON: [SpatialPlan-kayttotarkoituskohdistus](./SpatialPlan-kayttotarkoituskohdistus.md) (generoitu automaattisesti)
+
+
+## SpatialPlan-useampiKayttotarkoituskohdistus
+
+Variaatio esimerkistä "SpatialPlan-kayttotarkoituskohdistus" siten, että rakennusalalle X on sallittu rakentaa 2500 k-m2 liiketilaa ja 1500 k-m2 toimistotilaa. Määräys on toteutettu niin, että rakennusalaan X kohdistuvassa kaavamääräysryhmässä on kaksi Sallittu kerrosala -lajin kaavamääräystä, joissa molemmissa oma käyttötarkoituskohdistus.
+
+YAML: [SpatialPlan-useampiKayttotarkoituskohdistus.yml](./SpatialPlan-useampiKayttotarkoituskohdistus.yml)
+
+JSON: [SpatialPlan-useampiKayttotarkoituskohdistus](./SpatialPlan-useampiKayttotarkoituskohdistus.md) (generoitu automaattisesti)

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/README.md
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/README.md
@@ -21,8 +21,24 @@ JSON: [SpatialPlan-kayttotarkoituskohdistus](./SpatialPlan-kayttotarkoituskohdis
 
 ## SpatialPlan-useampiKayttotarkoituskohdistus
 
-Variaatio esimerkistä "SpatialPlan-kayttotarkoituskohdistus" siten, että rakennusalalle X on sallittu rakentaa 2500 k-m2 liiketilaa ja 1500 k-m2 toimistotilaa. Määräys on toteutettu niin, että rakennusalaan X kohdistuvassa kaavamääräysryhmässä on kaksi Sallittu kerrosala -lajin kaavamääräystä, joissa molemmissa oma käyttötarkoituskohdistus.
+Variaatio esimerkistä "SpatialPlan-kayttotarkoituskohdistus" siten, että rakennusalalle X on sallittu rakentaa 2500 k-m2 asuinrakentamista ja 1500 k-m2 toimistotilaa ja rakennusalalle XII on sallittu rakentaa 6000 k-m2 asuinrakentamista. Määräys on toteutettu niin, että rakennusalaan X kohdistuvassa kaavamääräysryhmässä on kaksi Sallittu kerrosala -lajin kaavamääräystä, joissa molemmissa omat käyttötarkoituskohdistus -lisätiedot.
 
 YAML: [SpatialPlan-useampiKayttotarkoituskohdistus.yml](./SpatialPlan-useampiKayttotarkoituskohdistus.yml)
 
 JSON: [SpatialPlan-useampiKayttotarkoituskohdistus](./SpatialPlan-useampiKayttotarkoituskohdistus.md) (generoitu automaattisesti)
+
+## SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen
+
+Variaatio esimerkistä "SpatialPlan-kayttotarkoituskohdistus" siten, rakennusalalle X on sallittu 4000 k-m2 ja rakennusalalle XII 6000 k-m2 rakennusoikeutta ilman käyttötarkoituskohdistusta (korttelin sekoitettu käyttötarkoitus AL pätee ilman toimistorakentamista). Rakennusalalle X sallitusta kokonaiskerrosalasta (4000 k-m2) on erikseen varattu asumiselle 2000 k-m2 (vastaa merkintää "a2000m2") ja rakennusalan XII sallitusta kokonaiskerrosalasta (6000 k-m2)  liikerakentamiselle 3000 k-m2 (vastaa Katja-asetuksessa määrittelemätöntä merkintää "l3000m2").
+
+YAML: [SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.yml](./SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.yml)
+
+JSON: [SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen](./SpatialPlan-useampiKayttotarkoituskohdistus.md) (generoitu automaattisesti)
+
+## SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta
+
+Variaatio esimerkistä "SpatialPlan-kayttotarkoituskohdistus" siten, AL-korttelin alueelle on kokonaisuudessa sallittu 10000 k-m2 rakennusoikeutta jakamatta sitä sen sisältämien rakennusalojen kesken. Rakennusalalle X sallitusta kokonaiskerrosalasta on varattu asumiselle 2000 k-m2 (vastaa merkintää "a2000m2") ja rakennusalan XII sallitusta kokonaiskerrosalasta liikerakentamiselle 3000 k-m2 (vastaa Katja-asetuksessa määrittelemätöntä merkintää "l3000m2").
+
+YAML: [SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.yml](./SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.yml)
+
+JSON: [SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta](./SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.md) (generoitu automaattisesti)

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.md
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.md
@@ -1,0 +1,411 @@
+# json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen 
+Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.yml. Älä muokkaa tätä tiedostoa käsin.
+```json
+{
+  "planKey": "43ec642a-61d7-427d-9aa1-4046ca994b54",
+  "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+  "planDescription": "Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.\n\nKunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa alueelle laadukasta ja hyvää ympäristöä.",
+  "geographicalArea": {
+    "srid": "3880",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            26478230.97832,
+            7029409.73545
+          ],
+          [
+            26478319.31953,
+            7029563.05089
+          ],
+          [
+            26478367.60318,
+            7029567.15694
+          ],
+          [
+            26478423.13736,
+            7029571.87958
+          ],
+          [
+            26478592.47984,
+            7029586.2805
+          ],
+          [
+            26478535.52301,
+            7029392.31324
+          ],
+          [
+            26478372.27445,
+            7029401.65226
+          ],
+          [
+            26478230.97832,
+            7029409.73545
+          ]
+        ]
+      ]
+    }
+  },
+  "planObjects": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "AL-alueen kaavakohde"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Rakennusalan kaavakohde (X)"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478284.587792058,
+                7029448.382880019
+              ],
+              [
+                26478298.906324517,
+                7029489.757671134
+              ],
+              [
+                26478313.830975942,
+                7029522.25696673
+              ],
+              [
+                26478328.850461837,
+                7029548.678563602
+              ],
+              [
+                26478400.43867828,
+                7029546.054580463
+              ],
+              [
+                26478375.99466209,
+                7029464.305673082
+              ],
+              [
+                26478318.555287004,
+                7029429.2724726815
+              ],
+              [
+                26478284.587792058,
+                7029448.382880019
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Rakennusalan kaavakohde (XII)"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478455.683840297,
+                7029451.98787261
+              ],
+              [
+                26478459.68785487,
+                7029495.072244115
+              ],
+              [
+                26478479.78435936,
+                7029525.781729518
+              ],
+              [
+                26478481.08540883,
+                7029562.2771160025
+              ],
+              [
+                26478557.399859037,
+                7029556.45347509
+              ],
+              [
+                26478525.561856028,
+                7029409.1210731445
+              ],
+              [
+                26478477.714788258,
+                7029418.662328132
+              ],
+              [
+                26478455.683840297,
+                7029451.98787261
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    }
+  ],
+  "planRegulationGroups": [
+    {
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f",
+      "titleOfPlanRegulation": {
+        "fin": "Asuin- ja liikerakennusten alue"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "55e1f047-8c55-432a-9086-1642de870410",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        },
+        {
+          "planRegulationKey": "d603a78a-ed93-42e6-9802-d09646997041",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusala"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "51635e36-7531-474c-be5c-0f34912f8419",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "66a85df7-f315-4462-bb7e-0624dcdbfdfb",
+      "titleOfPlanRegulation": {
+        "fin": "Maanpäällinen kerrosluku: X"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "9f69517f-e87b-425a-9bb4-e0db9da76ea5",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 10
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "a32c320d-6780-4002-b46d-456b1d61623b",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusoikeus kerrosalaneliömetreinä"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "8cfb5dbc-8ae9-4476-a57a-8f349f7bc3f3",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 6000,
+            "unitOfMeasure": "k-m2"
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "c5e647b4-628e-448e-8c3f-a47a000347d1",
+      "titleOfPlanRegulation": {
+        "fin": "Maanpäällinen kerrosluku: XII"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "d88e2eb1-047e-41e1-88bc-b285047e4452",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 12
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "6993467f-3035-476f-a143-c90deee680bd",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusoikeus kerrosalaneliömetreinä"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "6a6060c9-f6f3-404a-a925-a5285d135dd4",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 4000,
+            "unitOfMeasure": "k-m2"
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "73072e98-5e9b-4377-b058-c1644d2a6daa",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää asuinhuoneistoja varten"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "6a001a27-d308-4355-89f3-9689b29cde62",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2",
+              "value": {
+                "dataType": "PositiveNumeric",
+                "number": 3000,
+                "unitOfMeasure": "k-m2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "9dd197cc-bed9-4a41-95a8-8057bfe37a5d",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää liikerakentamista varten"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "b6a816fe-88bd-446a-89c4-b3312f954cef",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2",
+              "value": {
+                "dataType": "PositiveNumeric",
+                "number": 2000,
+                "unitOfMeasure": "k-m2"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "planRegulationGroupRelations": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "66a85df7-f315-4462-bb7e-0624dcdbfdfb"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "6993467f-3035-476f-a143-c90deee680bd"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "9dd197cc-bed9-4a41-95a8-8057bfe37a5d"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "c5e647b4-628e-448e-8c3f-a47a000347d1"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "a32c320d-6780-4002-b46d-456b1d61623b"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "73072e98-5e9b-4377-b058-c1644d2a6daa"
+    }
+  ]
+}
+```

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.meta
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.meta
@@ -1,0 +1,2 @@
+planType: '31'
+administrativeAreaIdentifiers: '601'

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.yml
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen.yml
@@ -1,0 +1,256 @@
+planKey: 43ec642a-61d7-427d-9aa1-4046ca994b54
+lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+planDescription: >-
+  Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.
+
+
+  Kunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa
+  alueelle laadukasta ja hyvää ympäristöä.
+geographicalArea:
+  srid: '3880'
+  geometry:
+    type: Polygon
+    coordinates:
+      - - - 26478230.97832
+          - 7029409.73545
+        - - 26478319.31953
+          - 7029563.05089
+        - - 26478367.60318
+          - 7029567.15694
+        - - 26478423.13736
+          - 7029571.87958
+        - - 26478592.47984
+          - 7029586.2805
+        - - 26478535.52301
+          - 7029392.31324
+        - - 26478372.27445
+          - 7029401.65226
+        - - 26478230.97832
+          - 7029409.73545
+planObjects:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: AL-alueen kaavakohde
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478230.97832
+              - 7029409.73545
+            - - 26478319.31953
+              - 7029563.05089
+            - - 26478367.60318
+              - 7029567.15694
+            - - 26478423.13736
+              - 7029571.87958
+            - - 26478592.47984
+              - 7029586.2805
+            - - 26478535.52301
+              - 7029392.31324
+            - - 26478372.27445
+              - 7029401.65226
+            - - 26478230.97832
+              - 7029409.73545
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Rakennusalan kaavakohde (X)
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478284.587792058
+              - 7029448.382880019
+            - - 26478298.906324517
+              - 7029489.757671134
+            - - 26478313.830975942
+              - 7029522.25696673
+            - - 26478328.850461837
+              - 7029548.678563602
+            - - 26478400.43867828
+              - 7029546.054580463
+            - - 26478375.99466209
+              - 7029464.305673082
+            - - 26478318.555287004
+              - 7029429.2724726815
+            - - 26478284.587792058
+              - 7029448.382880019
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Rakennusalan kaavakohde (XII)
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478455.683840297
+              - 7029451.98787261
+            - - 26478459.68785487
+              - 7029495.072244115
+            - - 26478479.78435936
+              - 7029525.781729518
+            - - 26478481.08540883
+              - 7029562.2771160025
+            - - 26478557.399859037
+              - 7029556.45347509
+            - - 26478525.561856028
+              - 7029409.1210731445
+            - - 26478477.714788258
+              - 7029418.662328132
+            - - 26478455.683840297
+              - 7029451.98787261
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+planRegulationGroups:
+  - planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    titleOfPlanRegulation:
+      fin: Asuin- ja liikerakennusten alue
+    planRegulations:
+      - planRegulationKey: 55e1f047-8c55-432a-9086-1642de870410
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+      - planRegulationKey: d603a78a-ed93-42e6-9802-d09646997041
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+  - planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    titleOfPlanRegulation:
+      fin: Rakennusala
+    planRegulations:
+      - planRegulationKey: 51635e36-7531-474c-be5c-0f34912f8419
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue
+  - planRegulationGroupKey: 66a85df7-f315-4462-bb7e-0624dcdbfdfb
+    titleOfPlanRegulation:
+      fin: 'Maanpäällinen kerrosluku: X'
+    planRegulations:
+      - planRegulationKey: 9f69517f-e87b-425a-9bb4-e0db9da76ea5
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku
+        value:
+          dataType: PositiveNumeric
+          number: 10
+  - planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
+    titleOfPlanRegulation:
+      fin: Rakennusoikeus kerrosalaneliömetreinä
+    planRegulations:
+      - planRegulationKey: 8cfb5dbc-8ae9-4476-a57a-8f349f7bc3f3
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        value:
+          dataType: PositiveNumeric
+          number: 6000
+          unitOfMeasure: k-m2
+  - planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
+    titleOfPlanRegulation:
+      fin: 'Maanpäällinen kerrosluku: XII'
+    planRegulations:
+      - planRegulationKey: d88e2eb1-047e-41e1-88bc-b285047e4452
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku
+        value:
+          dataType: PositiveNumeric
+          number: 12
+  - planRegulationGroupKey: 6993467f-3035-476f-a143-c90deee680bd
+    titleOfPlanRegulation:
+      fin: Rakennusoikeus kerrosalaneliömetreinä
+    planRegulations:
+      - planRegulationKey: 6a6060c9-f6f3-404a-a925-a5285d135dd4
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        value:
+          dataType: PositiveNumeric
+          number: 4000
+          unitOfMeasure: k-m2
+  - planRegulationGroupKey: 73072e98-5e9b-4377-b058-c1644d2a6daa
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää asuinhuoneistoja varten
+    planRegulations:
+      - planRegulationKey: 6a001a27-d308-4355-89f3-9689b29cde62
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2
+            value:
+              dataType: PositiveNumeric
+              number: 3000
+              unitOfMeasure: k-m2
+  - planRegulationGroupKey: 9dd197cc-bed9-4a41-95a8-8057bfe37a5d
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää liikerakentamista varten
+    planRegulations:
+      - planRegulationKey: b6a816fe-88bd-446a-89c4-b3312f954cef
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2
+            value:
+              dataType: PositiveNumeric
+              number: 2000
+              unitOfMeasure: k-m2
+planRegulationGroupRelations:
+    # Asuin- ja liikerakennusten alue -> AL-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    #
+    # Rakennusala -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Maanpäällinen kerrosluku: X -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 66a85df7-f315-4462-bb7e-0624dcdbfdfb
+    #
+    # Rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 6993467f-3035-476f-a143-c90deee680bd
+    #
+    # Liikerakentamiseen kohdistettu rakennusoikeuden osuus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 9dd197cc-bed9-4a41-95a8-8057bfe37a5d
+    #
+    # Rakennusala -> Rakennusalan kaavakohde (XII): 
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Maanpäällinen kerrosluku: XII -> Rakennusalan kaavakohde (XII): 
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
+    #
+    # Rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (XII):
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
+    #
+    # Asumiseen kohdistettu rakennusoikeuden osuus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (XII):
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: 73072e98-5e9b-4377-b058-c1644d2a6daa
+
+
+

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.md
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.md
@@ -1,0 +1,389 @@
+# json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta 
+Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.yml. Älä muokkaa tätä tiedostoa käsin.
+```json
+{
+  "planKey": "43ec642a-61d7-427d-9aa1-4046ca994b54",
+  "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+  "planDescription": "Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.\n\nKunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa alueelle laadukasta ja hyvää ympäristöä.",
+  "geographicalArea": {
+    "srid": "3880",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            26478230.97832,
+            7029409.73545
+          ],
+          [
+            26478319.31953,
+            7029563.05089
+          ],
+          [
+            26478367.60318,
+            7029567.15694
+          ],
+          [
+            26478423.13736,
+            7029571.87958
+          ],
+          [
+            26478592.47984,
+            7029586.2805
+          ],
+          [
+            26478535.52301,
+            7029392.31324
+          ],
+          [
+            26478372.27445,
+            7029401.65226
+          ],
+          [
+            26478230.97832,
+            7029409.73545
+          ]
+        ]
+      ]
+    }
+  },
+  "planObjects": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "AL-alueen kaavakohde"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Rakennusalan kaavakohde (X)"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478284.587792058,
+                7029448.382880019
+              ],
+              [
+                26478298.906324517,
+                7029489.757671134
+              ],
+              [
+                26478313.830975942,
+                7029522.25696673
+              ],
+              [
+                26478328.850461837,
+                7029548.678563602
+              ],
+              [
+                26478400.43867828,
+                7029546.054580463
+              ],
+              [
+                26478375.99466209,
+                7029464.305673082
+              ],
+              [
+                26478318.555287004,
+                7029429.2724726815
+              ],
+              [
+                26478284.587792058,
+                7029448.382880019
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Rakennusalan kaavakohde (XII)"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478455.683840297,
+                7029451.98787261
+              ],
+              [
+                26478459.68785487,
+                7029495.072244115
+              ],
+              [
+                26478479.78435936,
+                7029525.781729518
+              ],
+              [
+                26478481.08540883,
+                7029562.2771160025
+              ],
+              [
+                26478557.399859037,
+                7029556.45347509
+              ],
+              [
+                26478525.561856028,
+                7029409.1210731445
+              ],
+              [
+                26478477.714788258,
+                7029418.662328132
+              ],
+              [
+                26478455.683840297,
+                7029451.98787261
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    }
+  ],
+  "planRegulationGroups": [
+    {
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f",
+      "titleOfPlanRegulation": {
+        "fin": "Asuin- ja liikerakennusten alue"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "55e1f047-8c55-432a-9086-1642de870410",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        },
+        {
+          "planRegulationKey": "d603a78a-ed93-42e6-9802-d09646997041",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "a32c320d-6780-4002-b46d-456b1d61623b",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusoikeus kerrosalaneliömetreinä"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "8cfb5dbc-8ae9-4476-a57a-8f349f7bc3f3",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 10000,
+            "unitOfMeasure": "k-m2"
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusala"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "51635e36-7531-474c-be5c-0f34912f8419",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "66a85df7-f315-4462-bb7e-0624dcdbfdfb",
+      "titleOfPlanRegulation": {
+        "fin": "Maanpäällinen kerrosluku: X"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "9f69517f-e87b-425a-9bb4-e0db9da76ea5",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 10
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "c5e647b4-628e-448e-8c3f-a47a000347d1",
+      "titleOfPlanRegulation": {
+        "fin": "Maanpäällinen kerrosluku: XII"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "d88e2eb1-047e-41e1-88bc-b285047e4452",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 12
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "73072e98-5e9b-4377-b058-c1644d2a6daa",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää asuinhuoneistoja varten"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "6a001a27-d308-4355-89f3-9689b29cde62",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2",
+              "value": {
+                "dataType": "PositiveNumeric",
+                "number": 3000,
+                "unitOfMeasure": "k-m2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "9dd197cc-bed9-4a41-95a8-8057bfe37a5d",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää liikerakentamista varten"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "b6a816fe-88bd-446a-89c4-b3312f954cef",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2",
+              "value": {
+                "dataType": "PositiveNumeric",
+                "number": 2000,
+                "unitOfMeasure": "k-m2"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "planRegulationGroupRelations": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f"
+    },
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "a32c320d-6780-4002-b46d-456b1d61623b"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "66a85df7-f315-4462-bb7e-0624dcdbfdfb"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "9dd197cc-bed9-4a41-95a8-8057bfe37a5d"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "c5e647b4-628e-448e-8c3f-a47a000347d1"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "73072e98-5e9b-4377-b058-c1644d2a6daa"
+    }
+  ]
+}
+```

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.meta
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.meta
@@ -1,0 +1,2 @@
+planType: '31'
+administrativeAreaIdentifiers: '601'

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.yml
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta.yml
@@ -1,0 +1,240 @@
+planKey: 43ec642a-61d7-427d-9aa1-4046ca994b54
+lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+planDescription: >-
+  Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.
+
+
+  Kunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa
+  alueelle laadukasta ja hyvää ympäristöä.
+geographicalArea:
+  srid: '3880'
+  geometry:
+    type: Polygon
+    coordinates:
+      - - - 26478230.97832
+          - 7029409.73545
+        - - 26478319.31953
+          - 7029563.05089
+        - - 26478367.60318
+          - 7029567.15694
+        - - 26478423.13736
+          - 7029571.87958
+        - - 26478592.47984
+          - 7029586.2805
+        - - 26478535.52301
+          - 7029392.31324
+        - - 26478372.27445
+          - 7029401.65226
+        - - 26478230.97832
+          - 7029409.73545
+planObjects:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: AL-alueen kaavakohde
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478230.97832
+              - 7029409.73545
+            - - 26478319.31953
+              - 7029563.05089
+            - - 26478367.60318
+              - 7029567.15694
+            - - 26478423.13736
+              - 7029571.87958
+            - - 26478592.47984
+              - 7029586.2805
+            - - 26478535.52301
+              - 7029392.31324
+            - - 26478372.27445
+              - 7029401.65226
+            - - 26478230.97832
+              - 7029409.73545
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Rakennusalan kaavakohde (X)
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478284.587792058
+              - 7029448.382880019
+            - - 26478298.906324517
+              - 7029489.757671134
+            - - 26478313.830975942
+              - 7029522.25696673
+            - - 26478328.850461837
+              - 7029548.678563602
+            - - 26478400.43867828
+              - 7029546.054580463
+            - - 26478375.99466209
+              - 7029464.305673082
+            - - 26478318.555287004
+              - 7029429.2724726815
+            - - 26478284.587792058
+              - 7029448.382880019
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Rakennusalan kaavakohde (XII)
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478455.683840297
+              - 7029451.98787261
+            - - 26478459.68785487
+              - 7029495.072244115
+            - - 26478479.78435936
+              - 7029525.781729518
+            - - 26478481.08540883
+              - 7029562.2771160025
+            - - 26478557.399859037
+              - 7029556.45347509
+            - - 26478525.561856028
+              - 7029409.1210731445
+            - - 26478477.714788258
+              - 7029418.662328132
+            - - 26478455.683840297
+              - 7029451.98787261
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+planRegulationGroups:
+  - planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    titleOfPlanRegulation:
+      fin: Asuin- ja liikerakennusten alue
+    planRegulations:
+      - planRegulationKey: 55e1f047-8c55-432a-9086-1642de870410
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+      - planRegulationKey: d603a78a-ed93-42e6-9802-d09646997041
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+  - planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
+    titleOfPlanRegulation:
+      fin: Rakennusoikeus kerrosalaneliömetreinä
+    planRegulations:
+      - planRegulationKey: 8cfb5dbc-8ae9-4476-a57a-8f349f7bc3f3
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        value:
+          dataType: PositiveNumeric
+          number: 10000
+          unitOfMeasure: k-m2
+  - planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    titleOfPlanRegulation:
+      fin: Rakennusala
+    planRegulations:
+      - planRegulationKey: 51635e36-7531-474c-be5c-0f34912f8419
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue
+  - planRegulationGroupKey: 66a85df7-f315-4462-bb7e-0624dcdbfdfb
+    titleOfPlanRegulation:
+      fin: 'Maanpäällinen kerrosluku: X'
+    planRegulations:
+      - planRegulationKey: 9f69517f-e87b-425a-9bb4-e0db9da76ea5
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku
+        value:
+          dataType: PositiveNumeric
+          number: 10
+  - planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
+    titleOfPlanRegulation:
+      fin: 'Maanpäällinen kerrosluku: XII'
+    planRegulations:
+      - planRegulationKey: d88e2eb1-047e-41e1-88bc-b285047e4452
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku
+        value:
+          dataType: PositiveNumeric
+          number: 12
+  - planRegulationGroupKey: 73072e98-5e9b-4377-b058-c1644d2a6daa
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää asuinhuoneistoja varten
+    planRegulations:
+      - planRegulationKey: 6a001a27-d308-4355-89f3-9689b29cde62
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2
+            value:
+              dataType: PositiveNumeric
+              number: 3000
+              unitOfMeasure: k-m2
+  - planRegulationGroupKey: 9dd197cc-bed9-4a41-95a8-8057bfe37a5d
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta neliömetriä rakennusalalle sallitusta kerrostilavuudesta saadaan käyttää liikerakentamista varten
+    planRegulations:
+      - planRegulationKey: b6a816fe-88bd-446a-89c4-b3312f954cef
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituksenOsuusKerrosalastaK-m2
+            value:
+              dataType: PositiveNumeric
+              number: 2000
+              unitOfMeasure: k-m2
+planRegulationGroupRelations:
+    # Asuin- ja liikerakennusten alue -> AL-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    #
+    # Rakennusoikeus kerrosalaneliömetreinä -> AL-alueen kaavakohde:
+  - planObjectKey:  c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
+    #
+    # Rakennusala -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Maanpäällinen kerrosluku: X -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 66a85df7-f315-4462-bb7e-0624dcdbfdfb
+    #
+    # Liikerakentamiseen kohdistettu rakennusoikeuden osuus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 9dd197cc-bed9-4a41-95a8-8057bfe37a5d
+    #
+    # Rakennusala -> Rakennusalan kaavakohde (XII): 
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Maanpäällinen kerrosluku: XII -> Rakennusalan kaavakohde (XII): 
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
+    #
+    # Asumiseen kohdistettu rakennusoikeuden osuus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (XII):
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: 73072e98-5e9b-4377-b058-c1644d2a6daa
+
+
+

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.md
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.md
@@ -1,0 +1,397 @@
+# json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus 
+Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.yml. Älä muokkaa tätä tiedostoa käsin.
+```json
+{
+  "planKey": "43ec642a-61d7-427d-9aa1-4046ca994b54",
+  "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+  "planDescription": "Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.\n\nKunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa alueelle laadukasta ja hyvää ympäristöä.",
+  "geographicalArea": {
+    "srid": "3880",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            26478230.97832,
+            7029409.73545
+          ],
+          [
+            26478319.31953,
+            7029563.05089
+          ],
+          [
+            26478367.60318,
+            7029567.15694
+          ],
+          [
+            26478423.13736,
+            7029571.87958
+          ],
+          [
+            26478592.47984,
+            7029586.2805
+          ],
+          [
+            26478535.52301,
+            7029392.31324
+          ],
+          [
+            26478372.27445,
+            7029401.65226
+          ],
+          [
+            26478230.97832,
+            7029409.73545
+          ]
+        ]
+      ]
+    }
+  },
+  "planObjects": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "AL-alueen kaavakohde"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478230.97832,
+                7029409.73545
+              ],
+              [
+                26478319.31953,
+                7029563.05089
+              ],
+              [
+                26478367.60318,
+                7029567.15694
+              ],
+              [
+                26478423.13736,
+                7029571.87958
+              ],
+              [
+                26478592.47984,
+                7029586.2805
+              ],
+              [
+                26478535.52301,
+                7029392.31324
+              ],
+              [
+                26478372.27445,
+                7029401.65226
+              ],
+              [
+                26478230.97832,
+                7029409.73545
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Rakennusalan kaavakohde (X)"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478284.587792058,
+                7029448.382880019
+              ],
+              [
+                26478298.906324517,
+                7029489.757671134
+              ],
+              [
+                26478313.830975942,
+                7029522.25696673
+              ],
+              [
+                26478328.850461837,
+                7029548.678563602
+              ],
+              [
+                26478400.43867828,
+                7029546.054580463
+              ],
+              [
+                26478375.99466209,
+                7029464.305673082
+              ],
+              [
+                26478318.555287004,
+                7029429.2724726815
+              ],
+              [
+                26478284.587792058,
+                7029448.382880019
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+      "name": {
+        "fin": "Rakennusalan kaavakohde (XII)"
+      },
+      "geometry": {
+        "srid": "3880",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                26478455.683840297,
+                7029451.98787261
+              ],
+              [
+                26478459.68785487,
+                7029495.072244115
+              ],
+              [
+                26478479.78435936,
+                7029525.781729518
+              ],
+              [
+                26478481.08540883,
+                7029562.2771160025
+              ],
+              [
+                26478557.399859037,
+                7029556.45347509
+              ],
+              [
+                26478525.561856028,
+                7029409.1210731445
+              ],
+              [
+                26478477.714788258,
+                7029418.662328132
+              ],
+              [
+                26478455.683840297,
+                7029451.98787261
+              ]
+            ]
+          ]
+        }
+      },
+      "undergroundStatus": "http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02",
+      "relatedPlanObjectKeys": [
+        "c4667f08-4a3b-4113-ace8-cce749facbba"
+      ]
+    }
+  ],
+  "planRegulationGroups": [
+    {
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f",
+      "titleOfPlanRegulation": {
+        "fin": "Asuin- ja liikerakennusten alue"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "55e1f047-8c55-432a-9086-1642de870410",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        },
+        {
+          "planRegulationKey": "d603a78a-ed93-42e6-9802-d09646997041",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e",
+      "titleOfPlanRegulation": {
+        "fin": "Rakennusala"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "51635e36-7531-474c-be5c-0f34912f8419",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "66a85df7-f315-4462-bb7e-0624dcdbfdfb",
+      "titleOfPlanRegulation": {
+        "fin": "Maanpäällinen kerrosluku: X"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "9f69517f-e87b-425a-9bb4-e0db9da76ea5",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 10
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "a32c320d-6780-4002-b46d-456b1d61623b",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää asuinhuoneistoja varten"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "8cfb5dbc-8ae9-4476-a57a-8f349f7bc3f3",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus",
+              "value": {
+                "dataType": "Code",
+                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
+                "codeList": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji"
+              }
+            }
+          ],
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 6000,
+            "unitOfMeasure": "k-m2"
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "c5e647b4-628e-448e-8c3f-a47a000347d1",
+      "titleOfPlanRegulation": {
+        "fin": "Maanpäällinen kerrosluku: XII"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "d88e2eb1-047e-41e1-88bc-b285047e4452",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku",
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 12
+          }
+        }
+      ]
+    },
+    {
+      "planRegulationGroupKey": "6993467f-3035-476f-a143-c90deee680bd",
+      "titleOfPlanRegulation": {
+        "fin": "Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää liiketilaa varten"
+      },
+      "planRegulations": [
+        {
+          "planRegulationKey": "6a6060c9-f6f3-404a-a925-a5285d135dd4",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus",
+              "value": {
+                "dataType": "Code",
+                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue",
+                "codeList": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji"
+              }
+            }
+          ],
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 2500,
+            "unitOfMeasure": "k-m2"
+          }
+        },
+        {
+          "planRegulationKey": "9010a0b7-d20e-42ca-9877-0dcfe49fbb7b",
+          "lifeCycleStatus": "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04",
+          "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala",
+          "additionalInformations": [
+            {
+              "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus",
+              "value": {
+                "dataType": "Code",
+                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/toimistorakennustenAlue",
+                "codeList": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji"
+              }
+            }
+          ],
+          "value": {
+            "dataType": "PositiveNumeric",
+            "number": 1500,
+            "unitOfMeasure": "k-m2"
+          }
+        }
+      ]
+    }
+  ],
+  "planRegulationGroupRelations": [
+    {
+      "planObjectKey": "c4667f08-4a3b-4113-ace8-cce749facbba",
+      "planRegulationGroupKey": "783f457a-a8cc-4bb6-a491-a15dac0c999f"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "66a85df7-f315-4462-bb7e-0624dcdbfdfb"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "c5e647b4-628e-448e-8c3f-a47a000347d1"
+    },
+    {
+      "planObjectKey": "7daff381-83f8-40d6-879a-7d63353621c9",
+      "planRegulationGroupKey": "a32c320d-6780-4002-b46d-456b1d61623b"
+    },
+    {
+      "planObjectKey": "ac314efb-3298-4e26-8358-8a17a16eb0c8",
+      "planRegulationGroupKey": "6993467f-3035-476f-a143-c90deee680bd"
+    }
+  ]
+}
+```

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.md
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.md
@@ -317,7 +317,7 @@ Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/sallittuKerr
     {
       "planRegulationGroupKey": "6993467f-3035-476f-a143-c90deee680bd",
       "titleOfPlanRegulation": {
-        "fin": "Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää liiketilaa varten"
+        "fin": "Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää asumista ja liiketilaa varten"
       },
       "planRegulations": [
         {
@@ -349,7 +349,7 @@ Automaattisesti generoitu YAML-tiedostosta json-esimerkit/kaavoitus/sallittuKerr
               "type": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus",
               "value": {
                 "dataType": "Code",
-                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/toimistorakennustenAlue",
+                "code": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue",
                 "codeList": "http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji"
               }
             }

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.meta
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.meta
@@ -1,0 +1,2 @@
+planType: '31'
+administrativeAreaIdentifiers: '601'

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.yml
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.yml
@@ -183,7 +183,7 @@ planRegulationGroups:
           number: 12
   - planRegulationGroupKey: 6993467f-3035-476f-a143-c90deee680bd
     titleOfPlanRegulation:
-      fin: Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää liiketilaa varten
+      fin: Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää asumista ja liiketilaa varten
     planRegulations:
       - planRegulationKey: 6a6060c9-f6f3-404a-a925-a5285d135dd4
         lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
@@ -211,7 +211,7 @@ planRegulationGroups:
             value:
               dataType: Code
               code: >-
-                http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/toimistorakennustenAlue
+                http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
               codeList: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
         value:
           dataType: PositiveNumeric
@@ -238,11 +238,11 @@ planRegulationGroupRelations:
   - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
     planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
     #
-    # Asumiselle varattu rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (XII):
+    # Asumiselle ja liiketilalle varattu rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (XII):
   - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
     planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
     #
-    # Liike- ja toimistorakentamiselle varattu rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (X):
+    # Asumiselle varattu rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (X):
   - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
     planRegulationGroupKey: 6993467f-3035-476f-a143-c90deee680bd
 

--- a/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.yml
+++ b/json-esimerkit/kaavoitus/sallittuKerrosala/SpatialPlan-useampiKayttotarkoituskohdistus.yml
@@ -1,0 +1,248 @@
+planKey: 43ec642a-61d7-427d-9aa1-4046ca994b54
+lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+planDescription: >-
+  Asemakaavahanke pohjautuu kunnan ja maanomistajien aloitteeseen.
+
+
+  Kunnan tavoitteena on edistää alueen elinkeinotoimintaa sekä muodostaa
+  alueelle laadukasta ja hyvää ympäristöä.
+geographicalArea:
+  srid: '3880'
+  geometry:
+    type: Polygon
+    coordinates:
+      - - - 26478230.97832
+          - 7029409.73545
+        - - 26478319.31953
+          - 7029563.05089
+        - - 26478367.60318
+          - 7029567.15694
+        - - 26478423.13736
+          - 7029571.87958
+        - - 26478592.47984
+          - 7029586.2805
+        - - 26478535.52301
+          - 7029392.31324
+        - - 26478372.27445
+          - 7029401.65226
+        - - 26478230.97832
+          - 7029409.73545
+planObjects:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: AL-alueen kaavakohde
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478230.97832
+              - 7029409.73545
+            - - 26478319.31953
+              - 7029563.05089
+            - - 26478367.60318
+              - 7029567.15694
+            - - 26478423.13736
+              - 7029571.87958
+            - - 26478592.47984
+              - 7029586.2805
+            - - 26478535.52301
+              - 7029392.31324
+            - - 26478372.27445
+              - 7029401.65226
+            - - 26478230.97832
+              - 7029409.73545
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Rakennusalan kaavakohde (X)
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478284.587792058
+              - 7029448.382880019
+            - - 26478298.906324517
+              - 7029489.757671134
+            - - 26478313.830975942
+              - 7029522.25696673
+            - - 26478328.850461837
+              - 7029548.678563602
+            - - 26478400.43867828
+              - 7029546.054580463
+            - - 26478375.99466209
+              - 7029464.305673082
+            - - 26478318.555287004
+              - 7029429.2724726815
+            - - 26478284.587792058
+              - 7029448.382880019
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+    name:
+      fin: Rakennusalan kaavakohde (XII)
+    geometry:
+      srid: '3880'
+      geometry:
+        type: Polygon
+        coordinates:
+          - - - 26478455.683840297
+              - 7029451.98787261
+            - - 26478459.68785487
+              - 7029495.072244115
+            - - 26478479.78435936
+              - 7029525.781729518
+            - - 26478481.08540883
+              - 7029562.2771160025
+            - - 26478557.399859037
+              - 7029556.45347509
+            - - 26478525.561856028
+              - 7029409.1210731445
+            - - 26478477.714788258
+              - 7029418.662328132
+            - - 26478455.683840297
+              - 7029451.98787261
+    undergroundStatus: http://uri.suomi.fi/codelist/rytj/RY_MaanalaisuudenLaji/code/02
+    relatedPlanObjectKeys:
+      - c4667f08-4a3b-4113-ace8-cce749facbba
+planRegulationGroups:
+  - planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    titleOfPlanRegulation:
+      fin: Asuin- ja liikerakennusten alue
+    planRegulations:
+      - planRegulationKey: 55e1f047-8c55-432a-9086-1642de870410
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+      - planRegulationKey: d603a78a-ed93-42e6-9802-d09646997041
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/paakayttotarkoitus
+  - planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    titleOfPlanRegulation:
+      fin: Rakennusala
+    planRegulations:
+      - planRegulationKey: 51635e36-7531-474c-be5c-0f34912f8419
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/rakennusala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/osaAlue
+  - planRegulationGroupKey: 66a85df7-f315-4462-bb7e-0624dcdbfdfb
+    titleOfPlanRegulation:
+      fin: 'Maanpäällinen kerrosluku: X'
+    planRegulations:
+      - planRegulationKey: 9f69517f-e87b-425a-9bb4-e0db9da76ea5
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku
+        value:
+          dataType: PositiveNumeric
+          number: 10
+  - planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää asuinhuoneistoja varten
+    planRegulations:
+      - planRegulationKey: 8cfb5dbc-8ae9-4476-a57a-8f349f7bc3f3
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus
+            value:
+              dataType: Code
+              code: >-
+                http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/asumisenAlue
+              codeList: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
+        value:
+          dataType: PositiveNumeric
+          number: 6000
+          unitOfMeasure: k-m2
+  - planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
+    titleOfPlanRegulation:
+      fin: 'Maanpäällinen kerrosluku: XII'
+    planRegulations:
+      - planRegulationKey: d88e2eb1-047e-41e1-88bc-b285047e4452
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/maanpaallinenKerroslukuLuku
+        value:
+          dataType: PositiveNumeric
+          number: 12
+  - planRegulationGroupKey: 6993467f-3035-476f-a143-c90deee680bd
+    titleOfPlanRegulation:
+      fin: Määräys osoittaa, kuinka monta kerrosneliömetriä rakennusalalle sallitusta kerrosalasta saadaan käyttää liiketilaa varten
+    planRegulations:
+      - planRegulationKey: 6a6060c9-f6f3-404a-a925-a5285d135dd4
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus
+            value:
+              dataType: Code
+              code: >-
+                http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/liikerakennustenAlue
+              codeList: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
+        value:
+          dataType: PositiveNumeric
+          number: 2500
+          unitOfMeasure: k-m2
+      - planRegulationKey: 9010a0b7-d20e-42ca-9877-0dcfe49fbb7b
+        lifeCycleStatus: http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/04
+        type: >-
+          http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/sallittuKerrosala
+        additionalInformations:
+          - type: >-
+              http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayksen_Lisatiedonlaji/code/kayttotarkoituskohdistus
+            value:
+              dataType: Code
+              code: >-
+                http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji/code/toimistorakennustenAlue
+              codeList: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
+        value:
+          dataType: PositiveNumeric
+          number: 1500
+          unitOfMeasure: k-m2
+planRegulationGroupRelations:
+    # Asuin- ja liikerakennusten alue -> AL-alueen kaavakohde:
+  - planObjectKey: c4667f08-4a3b-4113-ace8-cce749facbba
+    planRegulationGroupKey: 783f457a-a8cc-4bb6-a491-a15dac0c999f
+    #
+    # Rakennusala -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Rakennusala -> Rakennusalan kaavakohde (XII): 
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: d3ba28c8-4bfa-4e9b-87c7-5208d9a77b9e
+    #
+    # Maanpäällinen kerrosluku: X -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 66a85df7-f315-4462-bb7e-0624dcdbfdfb
+    #
+    # Maanpäällinen kerrosluku: XII -> Rakennusalan kaavakohde (XII): 
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: c5e647b4-628e-448e-8c3f-a47a000347d1
+    #
+    # Asumiselle varattu rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (XII):
+  - planObjectKey: 7daff381-83f8-40d6-879a-7d63353621c9
+    planRegulationGroupKey: a32c320d-6780-4002-b46d-456b1d61623b
+    #
+    # Liike- ja toimistorakentamiselle varattu rakennusoikeus kerrosalaneliömetreinä -> Rakennusalan kaavakohde (X):
+  - planObjectKey: ac314efb-3298-4e26-8358-8a17a16eb0c8
+    planRegulationGroupKey: 6993467f-3035-476f-a143-c90deee680bd
+


### PR DESCRIPTION
* SpatialPlan-useampiKayttotarkoituskohdistus (fixes #9),
* SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseen (fixes #11) ja
*  SpatialPlan-osaRakennusalastaVarattuKayttotarkoitukseenEiRakennusalakohtaistaRakennusoikeutta (fixes #15)